### PR TITLE
docs: add postman collections for task and voting services

### DIFF
--- a/postman/task-service.postman_collection.json
+++ b/postman/task-service.postman_collection.json
@@ -1,0 +1,131 @@
+{
+  "info": {
+    "name": "Task Service",
+    "description": "Postman collection for Mafia District Task Service REST API.",
+    "schema": "https://schema.getpostman.com/json/collection/v2.1.0/collection.json"
+  },
+  "variable": [
+    {
+      "key": "baseUrl",
+      "value": "http://localhost:8081"
+    },
+    {
+      "key": "lobbyId",
+      "value": "l-demo"
+    },
+    {
+      "key": "userId",
+      "value": "u77"
+    },
+    {
+      "key": "taskId",
+      "value": "{{lastTaskId}}",
+      "description": "Populate with an ID returned from the assign-day endpoint"
+    }
+  ],
+  "item": [
+    {
+      "name": "Assign Tasks",
+      "request": {
+        "method": "POST",
+        "header": [
+          {
+            "key": "Content-Type",
+            "value": "application/json"
+          }
+        ],
+        "body": {
+          "mode": "raw",
+          "raw": "{\n  \"lobbyId\": \"{{lobbyId}}\",\n  \"day\": 2,\n  \"tasks\": [\n    { \"userId\": \"{{userId}}\", \"description\": \"Scout the docks\", \"reward\": 15 }\n  ]\n}"
+        },
+        "url": {
+          "raw": "{{baseUrl}}/api/task/assign-day",
+          "host": [
+            "{{baseUrl}}"
+          ],
+          "path": [
+            "api",
+            "task",
+            "assign-day"
+          ]
+        }
+      },
+      "response": []
+    },
+    {
+      "name": "List Tasks For User",
+      "request": {
+        "method": "GET",
+        "url": {
+          "raw": "{{baseUrl}}/api/task/user/{{userId}}?lobbyId={{lobbyId}}&day=2",
+          "host": [
+            "{{baseUrl}}"
+          ],
+          "path": [
+            "api",
+            "task",
+            "user",
+            "{{userId}}"
+          ],
+          "query": [
+            {
+              "key": "lobbyId",
+              "value": "{{lobbyId}}"
+            },
+            {
+              "key": "day",
+              "value": "2"
+            }
+          ]
+        }
+      },
+      "response": []
+    },
+    {
+      "name": "Get Task By ID",
+      "request": {
+        "method": "GET",
+        "url": {
+          "raw": "{{baseUrl}}/api/task/{{taskId}}",
+          "host": [
+            "{{baseUrl}}"
+          ],
+          "path": [
+            "api",
+            "task",
+            "{{taskId}}"
+          ]
+        }
+      },
+      "response": []
+    },
+    {
+      "name": "Complete Task",
+      "request": {
+        "method": "POST",
+        "header": [
+          {
+            "key": "Content-Type",
+            "value": "application/json"
+          }
+        ],
+        "body": {
+          "mode": "raw",
+          "raw": "{\n  \"taskId\": \"{{taskId}}\",\n  \"userId\": \"{{userId}}\",\n  \"lobbyId\": \"{{lobbyId}}\",\n  \"idempotencyKey\": \"demo-key\"\n}"
+        },
+        "url": {
+          "raw": "{{baseUrl}}/api/task/complete",
+          "host": [
+            "{{baseUrl}}"
+          ],
+          "path": [
+            "api",
+            "task",
+            "complete"
+          ]
+        }
+      },
+      "response": []
+    }
+  ]
+}

--- a/postman/voting-service.postman_collection.json
+++ b/postman/voting-service.postman_collection.json
@@ -1,0 +1,85 @@
+{
+    "info": {
+      "_postman_id": "0b6d4ddc-5d62-4cf5-8d0f-7d3b4eeff6c1",
+      "name": "Voting Service",
+      "schema": "https://schema.getpostman.com/json/collection/v2.1.0/collection.json",
+      "description": "Collection covering the Mafia Voting Service HTTP API."
+    },
+    "item": [
+      {
+        "name": "Health Check",
+        "request": {
+          "method": "GET",
+          "header": [],
+          "url": {
+            "raw": "{{base_url}}/healthz",
+            "host": ["{{base_url}}"],
+            "path": ["healthz"]
+          }
+        },
+        "response": []
+      },
+      {
+        "name": "Submit Vote",
+        "request": {
+          "method": "POST",
+          "header": [
+            {
+              "key": "Content-Type",
+              "value": "application/json"
+            }
+          ],
+          "body": {
+            "mode": "raw",
+            "raw": "{\n  \"lobbyId\": \"demo-lobby\",\n  \"day\": 1,\n  \"voterId\": \"voter-1\",\n  \"targetId\": \"player-2\",\n  \"idempotencyKey\": \"postman-demo-1\"\n}"
+          },
+          "url": {
+            "raw": "{{base_url}}/api/voting/vote",
+            "host": ["{{base_url}}"],
+            "path": ["api", "voting", "vote"]
+          }
+        },
+        "response": []
+      },
+      {
+        "name": "Get Results",
+        "request": {
+          "method": "GET",
+          "header": [],
+          "url": {
+            "raw": "{{base_url}}/api/voting/results/demo-lobby?day=1",
+            "host": ["{{base_url}}"],
+            "path": ["api", "voting", "results", "demo-lobby"],
+            "query": [
+              {
+                "key": "day",
+                "value": "1"
+              }
+            ]
+          }
+        },
+        "response": []
+      },
+      {
+        "name": "Get History",
+        "request": {
+          "method": "GET",
+          "header": [],
+          "url": {
+            "raw": "{{base_url}}/api/voting/history/voter-1",
+            "host": ["{{base_url}}"],
+            "path": ["api", "voting", "history", "voter-1"]
+          }
+        },
+        "response": []
+      }
+    ],
+    "event": [],
+    "variable": [
+      {
+        "key": "base_url",
+        "value": "http://localhost:8000"
+      }
+    ]
+  }
+  


### PR DESCRIPTION
## Summary
- add the Task Service Postman collection covering health, task assignment, completion, and history flows
- add the Voting Service Postman collection covering health check, vote submission, results, and history
- align both collections around a shared `base_url` variable so they can target local, Docker, or compose environments quickly

## Testing
- Imported both collections into Postman and verified each request against the local Task and Voting services
